### PR TITLE
fix: upgrade tags for compatibility

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{@site.lang}}">
+<html lang="{{@site.locale}}">
 <head>
 
     {{!-- Document Settings --}}
@@ -55,7 +55,7 @@
     </div>
 
     {{!-- The big email subscribe modal content --}}
-    {{#if @labs.members}}
+    {{#if @site.members_enabled}}
     <div class="subscribe-success-message">
         <a class="subscribe-close" href="javascript:;"></a>
         You've successfully subscribed to {{@site.title}}!

--- a/index.hbs
+++ b/index.hbs
@@ -40,7 +40,7 @@ into the {body} of the default.hbs template --}}
         </div>
 
         {{!-- Email subscribe form at the bottom of the page --}}
-        {{#if @labs.members}}
+        {{#if @site.members_enabled}}
             {{> subscribe-form}}
         {{/if}}
     </div>

--- a/page.hbs
+++ b/page.hbs
@@ -14,28 +14,29 @@ into the {body} of the default.hbs template --}}
     <div class="inner">
 
         <article class="post-full {{post_class}} {{#unless feature_image}}no-image{{/unless}}">
+            {{#match @page.show_title_and_feature_image true}}
+                <header class="post-full-header">
+                    <h1 class="post-full-title">{{title}}</h1>
+                </header>
 
-            <header class="post-full-header">
-                <h1 class="post-full-title">{{title}}</h1>
-            </header>
-
-            {{#if feature_image}}
-            <figure class="post-full-image">
-                {{!-- This is a responsive image, it loads different sizes depending on device
-                https://medium.freecodecamp.org/a-guide-to-responsive-images-with-ready-to-use-templates-c400bd65c433 --}}
-                <img
-                    srcset="{{img_url feature_image size="s"}} 300w,
-                            {{img_url feature_image size="m"}} 600w,
-                            {{img_url feature_image size="l"}} 1000w,
-                            {{img_url feature_image size="xl"}} 2000w"
-                    sizes="(max-width: 800px) 400px,
-                            (max-width: 1170px) 1170px,
-                            2000px"
-                    src="{{img_url feature_image size="xl"}}"
-                    alt="{{title}}"
-                />
-            </figure>
-            {{/if}}
+                {{#if feature_image}}
+                <figure class="post-full-image">
+                    {{!-- This is a responsive image, it loads different sizes depending on device
+                    https://medium.freecodecamp.org/a-guide-to-responsive-images-with-ready-to-use-templates-c400bd65c433 --}}
+                    <img
+                        srcset="{{img_url feature_image size="s"}} 300w,
+                                {{img_url feature_image size="m"}} 600w,
+                                {{img_url feature_image size="l"}} 1000w,
+                                {{img_url feature_image size="xl"}} 2000w"
+                        sizes="(max-width: 800px) 400px,
+                                (max-width: 1170px) 1170px,
+                                2000px"
+                        src="{{img_url feature_image size="xl"}}"
+                        alt="{{title}}"
+                    />
+                </figure>
+                {{/if}}
+            {{/match}}
 
             <section class="post-full-content">
                 <div class="post-content">

--- a/post.hbs
+++ b/post.hbs
@@ -118,7 +118,7 @@ into the {body} of the default.hbs template --}}
             </section>
 
             {{!-- Email subscribe form at the bottom of the page --}}
-            {{#if @labs.members}}
+            {{#if @site.members_enabled}}
                 {{> subscribe-form}}
             {{/if}}
         </article>


### PR DESCRIPTION
Fix compatibility issues due to upgrading the Ghost version to

![image](https://github.com/user-attachments/assets/f544aa51-3c1b-44c2-b380-3e36d4eea1d6)
